### PR TITLE
Improve summary on case studies page

### DIFF
--- a/hugo-site/content/guides/case-studies-and-experiments/_index.md
+++ b/hugo-site/content/guides/case-studies-and-experiments/_index.md
@@ -8,6 +8,6 @@ sitemap:
   priority: 0.6
 ---
 
-This section presents a case study on Dialectical Narrative Generation, which serves as a practical example of the CNS 2.0 framework in action.
+The landscape of Artificial Intelligence (AI) is witnessing a transformative shift from mere data aggregation to sophisticated conflict resolution and knowledge synthesis, particularly in the domain of narrative generation. This report provides a high-level, strategic overview of advancements in applying dialectical reasoning to AI for crafting coherent narratives from complex and often disparate information sources. Key systems and frameworks, such as Chiral Narrative Synthesis (CNS) 2.0 and the Dialectical Framework, represent pioneering efforts in this field. These mechanisms are not merely automating storytelling; they are enabling AI to engage in higher-order reasoning, mimicking human intellectual progression through the identification, confrontation, and resolution of contradictions. The overarching challenges include maintaining narrative coherence, managing data bias, and ensuring ethical deployment, yet the future potential, especially in synergistic human-AI collaboration, is profound. These developments underscore the transformative impact of dialectical reasoning on generating insightful and trustworthy narratives from complex, multi-faceted information.
 
 [**(Read the full case study...)**](./dialectic-narrative-generation-research/)


### PR DESCRIPTION
The summary on the case studies and experiments page was very sparse. This change replaces the sparse summary with the executive summary from the linked case study, providing a more comprehensive overview of the research.