### PR TITLE
I have reorganized the weights for all pages within the `/guides/cns-…

### DIFF
--- a/hugo-site/content/guides/cns-2.0-research-roadmap/bibliography/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/bibliography/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Annotated Bibliography"
 description: "A curated list of the foundational papers and research that underpin the Chiral Narrative Synthesis 2.0 project."
-weight: 31 # After Guides
+weight: 16
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/blueprint/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/blueprint/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "CNS 2.0: A Practical Blueprint"
 description: "The canonical whitepaper detailing the architecture of Chiral Narrative Synthesis 2.0."
-weight: 30 # To place it after Ethics
+weight: 15
 sitemap:
   changefreq: monthly
   priority: 0.8

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-1-vision-vs-experiment.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-1-vision-vs-experiment.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 1: From Grand Vision to Focused Experiment"
 description: "Establishing experimental boundaries and statistical validation frameworks for the CNS 2.0 dialectical synthesis engine."
-weight: 2
+weight: 20
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-2-minimum-viable-experiment.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-2-minimum-viable-experiment.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 2: Statistical Prototype Framework for Dialectical Synthesis Validation"
 description: "Mathematical framework for scaling manual prototype validation to statistically significant experimental designs."
-weight: 3
+weight: 21
 lastmod: "2025-08-05"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-3-anatomy-of-a-paper.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-3-anatomy-of-a-paper.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 3: The Anatomy of a Research Paper"
 description: "Showing how the results from the Minimum Viable Experiment will be structured into a standard, high-quality academic paper."
-weight: 4
+weight: 22
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-4-foundational-work.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/chapter-4-foundational-work.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 4: Building on the Foundation"
 description: "Outlining the immediate research projects that build upon the MVE to enable the broader research vision."
-weight: 5
+weight: 23
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/ethical-legal-and-societal/1-bias-fairness-and-accountability.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/ethical-legal-and-societal/1-bias-fairness-and-accountability.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 1: Bias, Fairness, and Accountability"
 description: "Developing robust technical and policy frameworks to detect and mitigate bias, ensure fairness, and establish clear accountability for the CNS 2.0 system."
-weight: 15
+weight: 52
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/ethical-legal-and-societal/2-privacy-security-and-misuse-prevention.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/ethical-legal-and-societal/2-privacy-security-and-misuse-prevention.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 2: Privacy, Security & Misuse Prevention"
 description: "Developing technical and policy frameworks to protect user data, ensure system security, and prevent the CNS 2.0 system from being used for malicious purposes."
-weight: 16
+weight: 53
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/ethical-legal-and-societal/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/ethical-legal-and-societal/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Ethical, Legal, and Societal Research"
 description: "A proactive research program to investigate the ethical implications of CNS 2.0 and develop frameworks for its responsible deployment."
-weight: 14
+weight: 51
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/ethics/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/ethics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Ethics & Responsibility"
 description: "An overview of the ethical principles and frameworks guiding the responsible development of CNS 2.0."
-weight: 20 # To place it after Foundations
+weight: 50
 sitemap:
   changefreq: monthly
   priority: 0.7

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/1-longitudinal-and-cross-domain-studies.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/1-longitudinal-and-cross-domain-studies.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 1: Longitudinal & Cross-Domain Studies"
 description: "Evaluating the long-term performance stability and generalization capabilities of the CNS 2.0 system across time and diverse professional domains."
-weight: 11
+weight: 41
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/2-adversarial-robustness-and-security.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/2-adversarial-robustness-and-security.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 2: Adversarial Robustness & Security"
 description: "Conducting a rigorous security assessment of the CNS 2.0 system to test its resilience against sophisticated adversarial attacks and develop novel defenses."
-weight: 12
+weight: 42
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/3-human-ai-collaboration.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/3-human-ai-collaboration.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 3: Human-AI Collaboration"
 description: "Researching and optimizing the interaction between human experts and CNS 2.0 to create a seamless, trustworthy, and effective cognitive partnership."
-weight: 13
+weight: 43
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/evaluation-and-validation/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Evaluation and Validation Research"
 description: "A research program for rigorously assessing the performance, robustness, and utility of the CNS 2.0 system in diverse, real-world contexts."
-weight: 10
+weight: 40
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/future-research-directions.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/future-research-directions.md
@@ -1,7 +1,7 @@
 ---
 title: "Future Research Directions"
 description: "The next frontier for CNS: Evolving from a logic engine to a narrative intelligence system by integrating the deep structures of storytelling."
-weight: 50 # Places it at the end of the roadmap section
+weight: 61
 lastmod: "2025-08-06"
 sitemap:
   changefreq: yearly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/in-depth/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/in-depth/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "In-Depth Conceptual Guides"
 description: "Detailed explorations of the core technical and theoretical mechanisms that power the Chiral Narrative Synthesis 2.0 system."
-weight: 30
+weight: 12
 ---
 
 Welcome to the In-Depth section of the CNS 2.0 documentation.

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/in-depth/dialectical-reasoning-templates.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/in-depth/dialectical-reasoning-templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Dialectical Reasoning Templates"
 description: "A deep dive into the structured reasoning templates used by the CNS 2.0 synthesis engine to ensure logical consistency and mitigate hallucination."
-weight: 31
+weight: 13
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/in-depth/ideas-paper.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/in-depth/ideas-paper.md
@@ -1,7 +1,7 @@
 ---
 title: "CNS 2.0 Ideas Paper"
 description: "Ideas Paper - CNS 2.0: A Computational Framework for Chiral Narrative Synthesis in Automated Knowledge Discovery"
-weight: 32
+weight: 14
 lastmod: "2025-08-06"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/1-gnn-for-logical-reasoning.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/1-gnn-for-logical-reasoning.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 1: GNNs for Logical Reasoning"
 description: "Developing a next-generation, data-driven Logic Critic using Graph Neural Networks to assess the structural integrity of arguments."
-weight: 7
+weight: 31
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/2-federated-learning-and-privacy.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/2-federated-learning-and-privacy.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 2: Federated Learning and Privacy"
 description: "Designing a decentralized architecture for CNS 2.0 that enables collaborative knowledge synthesis while preserving data privacy."
-weight: 8
+weight: 32
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/3-formal-methods-and-causal-inference.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/3-formal-methods-and-causal-inference.md
@@ -1,7 +1,7 @@
 ---
 title: "Project 3: Formal Methods & Causal Inference"
 description: "Elevating CNS 2.0's reasoning capabilities by integrating formal logical systems and causal reasoning frameworks."
-weight: 9
+weight: 33
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/technical-research/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Advanced Technical Research"
 description: "Pushing the boundaries of the CNS 2.0 framework with next-generation models for reasoning, privacy, and inference."
-weight: 6
+weight: 30
 lastmod: "2025-07-30"
 sitemap:
   changefreq: monthly

--- a/hugo-site/content/guides/cns-2.0-research-roadmap/theoretical-foundations/_index.md
+++ b/hugo-site/content/guides/cns-2.0-research-roadmap/theoretical-foundations/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Theoretical Foundations"
 description: "The intellectual and academic foundations upon which Chiral Narrative Synthesis is built."
-weight: 10 # To place it after Overview
+weight: 11
 sitemap:
   changefreq: monthly
   priority: 0.6


### PR DESCRIPTION
…2.0-research-roadmap/` section to ensure they are grouped logically and follow the intended order outlined in the main `_index.md` file.

A new, consistent weighting scheme is now in place to group pages by their respective phases and sections, improving the navigational structure of the guide.

I was unable to modify one file, `quality-validation-review.md`, due to a persistent technical issue, so I skipped it as you instructed. Its weight remains unchanged. All other files have been successfully updated and verified.